### PR TITLE
feat: Add CI workflow for Heroku deploy

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: corepack enable
+      - run: corepack prepare yarn@1.22.19 --activate
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to Heroku
+        uses: akhileshns/heroku-deploy@v3.13.15
+        with:
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}
+          usedocker: true
+

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ next-env.d.ts
 .DS_Store
 Thumbs.db
 .env.local
+
+# Yarn
+.yarn/
+.yarnrc.yml

--- a/README.md
+++ b/README.md
@@ -215,6 +215,17 @@ The project includes configuration for:
 NEXT_PUBLIC_OPENAI_API_KEY=your_production_api_key
 NEXT_PUBLIC_OPENAI_ASSISTANT_ID=your_production_assistant_id
 ```
+### Continuous Integration and Deployment
+
+This repository includes a GitHub Actions workflow at `.github/workflows/test-and-deploy.yml` that runs tests on every push to `main` and deploys to Heroku if they pass.
+
+Add the following secrets in your GitHub repository settings:
+- `HEROKU_API_KEY` – your Heroku API key
+- `HEROKU_APP_NAME` – your Heroku app name
+- `HEROKU_EMAIL` – the email associated with the Heroku account
+
+Also ensure `NEXT_PUBLIC_OPENAI_API_KEY` and `NEXT_PUBLIC_OPENAI_ASSISTANT_ID` are set in the Heroku environment.
+
 
 ## 🛠️ Technologies & Dependencies
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests on push to main
- deploy to Heroku after tests succeed
- document CI/CD setup in README
- ignore Yarn's config files

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688115dabfe483338ac6b610c970307f